### PR TITLE
Updating git repo links

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,19 +30,10 @@ In the git-bash terminal:
 2. Turn off "python.exe" and "python3.exe" App Installers
 
 ## Installing
-Get this project from the Wright Group gitlab using "git clone *address*", using the address listed on the project page. For example, if you are on the Sunnybrook network and have ssh keys set up:
-`git clone git@panoptes.sri.utoronto.ca:wright-group/cathy.git`
-### SSH key setup
-More recent operating systems may not allow the default key encryption accepted by our older gitlab server. If the `git clone` command above fails try:
-1. Create an SSH config file: `touch ~/.ssh/config`
-2. Open the SSH config file in a text editor and copy this text in:
-```
-Host panoptes.sri.utoronto.ca
-  PubkeyAcceptedKeyTypes +ssh-rsa
-```
-Note the above will work for computers on the internal network: ssh config changes for remote access to gitlab from newer computers have not been tested.
+Get this project from github using "git clone" or "gh repo clone", using the address from the "Code" button dropdown with the protocol of your choice.
+
 ### Virtual Environments
-We recommend using [conda](https://conda.io/projects/conda/en/latest/user-guide/tasks/manage-environments.html) or [venv](https://packaging.python.org/guides/installing-using-pip-and-virtual-environments/) to isolate your Python development environments. Examples below will use conda 4.6+ (activating environments prior to conda 4.6 varies according to OS, please see the note in the intro of [conda](https://conda.io/projects/conda/en/latest/user-guide/tasks/manage-environments.html)).
+You can use [conda](https://conda.io/projects/conda/en/latest/user-guide/tasks/manage-environments.html) or [venv](https://packaging.python.org/guides/installing-using-pip-and-virtual-environments/) to isolate your Python development environments. Examples below will use conda 4.6+ (activating environments prior to conda 4.6 varies according to OS, please see the note in the intro of [conda](https://conda.io/projects/conda/en/latest/user-guide/tasks/manage-environments.html)).
 
 You can start by creating a conda environment with the tested version of Python. We've called it cathyEnv below, but you can name it as you wish:
 `conda create -n cathyEnv python=3.6`
@@ -55,15 +46,15 @@ Subsequent package installations with pip and conda, as detailed in the next sec
 
 ### Installing special dependencies
 
-cathy depends on the following packages which are currently only available on the Wright Group gitlab on panoptes. If you are not on the internal network, you will need to [set up remote access](https://wrightgroup.sri.utoronto.ca/tiki-download_file.php?fileId=278) and replace "panoptes.sri.utoronto.ca" in the links below with "localhost":
-- [catheter_utils](http://panoptes.sri.utoronto.ca:8088/wright-group/catheter_utils)
-- [catheter_ukf](http://panoptes.sri.utoronto.ca:8088/wright-group/catheter_ukf)
-- [dicom_utils](http://panoptes.sri.utoronto.ca:8088/wright-group/dicom_utils)
-- [dicom_art](http://panoptes.sri.utoronto.ca:8088/wright-group/dicom_art)
-- [get_gt](http://panoptes.sri.utoronto.ca:8088/wright-group/CLI_DataAugment) (from the CLI_DataAugment project)
+cathy depends on the following packages:
+- [catheter_utils](https://github.com/WrightGroupSRI/catheter_utils)
+- [catheter_ukf](https://github.com/WrightGroupSRI/catheter_ukf)
+- [dicom_utils](https://github.com/WrightGroupSRI/dicom_utils)
+- [dicom_art](https://github.com/WrightGroupSRI/dicom_art)
+- [get_gt](https://github.com/WrightGroupSRI/get_gt)
 
 For each of the dependencies above **in the order shown**, from your terminal:
-1. Perform the git clone. The git clone link is accessible via the SSH option for each project page.
+1. Perform the git clone. The git clone link is accessible from the "Code" button dropdown for each project page.
 2. A new project directory will be created after the previous command. Run `pip install -e [project_directory]` to install the package.
 
 #### ffmpeg


### PR DESCRIPTION
The code is now publicly available on github,
updating old links and instructions for legacy
server access.